### PR TITLE
Feat: run aws cli 2.x 

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function run(cmd, options = {}) {
     });
 }
 
-const accountLoginPassword = run(`aws ecr get-login-password`)
+const accountLoginPassword = run(`aws ecr get-login-password`);
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 

--- a/main.js
+++ b/main.js
@@ -24,10 +24,11 @@ function run(cmd, options = {}) {
     });
 }
 
+const accountLoginPassword = run(`$(aws ecr get-login-password)`)
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 
-run(`$(aws ecr get-login-password | docker login --password-stdin --username AWS ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
+run(`$(docker login --username AWS ${accountLoginPassword} ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
 
 if (direction === 'push') {
     if (!isSemver) {

--- a/main.js
+++ b/main.js
@@ -24,11 +24,11 @@ function run(cmd, options = {}) {
     });
 }
 
-const accountLoginPassword = run(`aws ecr get-login-password`).replace(/\n/g, '');
+const accountLoginPassword = `aws ecr get-login-password --region ${awsRegion}`;
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 
-run(`$(docker login --username AWS -p ${accountLoginPassword} ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
+run(`${accountLoginPassword} | docker login --username AWS --password-stdin ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com`);
 
 if (direction === 'push') {
     if (!isSemver) {

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function run(cmd, options = {}) {
     });
 }
 
-const accountLoginPassword = run(`aws ecr get-login-password`);
+const accountLoginPassword = run(`aws ecr get-login-password`).replace(/\n/g, '');
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ const accountLoginPassword = run(`aws ecr get-login-password`);
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 
-run(`$(docker login --username AWS ${accountLoginPassword} ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
+run(`$(docker login --username AWS -p ${accountLoginPassword} ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
 
 if (direction === 'push') {
     if (!isSemver) {

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function run(cmd, options = {}) {
     });
 }
 
-const accountLoginPassword = run(`$(aws ecr get-login-password)`)
+const accountLoginPassword = run(`aws ecr get-login-password`)
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ function run(cmd, options = {}) {
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
 
-run(`$(echo aws ecr get-login-password | docker login --password-stdin --username AWS ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
+run(`$(aws ecr get-login-password | docker login --password-stdin --username AWS ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
 
 if (direction === 'push') {
     if (!isSemver) {

--- a/main.js
+++ b/main.js
@@ -24,10 +24,10 @@ function run(cmd, options = {}) {
     });
 }
 
-run(`$(aws ecr get-login --no-include-email --region ${awsRegion})`);
-
 const accountData = run(`aws sts get-caller-identity --output json`);
 const awsAccountId = JSON.parse(accountData).Account;
+
+run(`$(echo aws ecr get-login-password | docker login --password-stdin --username AWS ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com)`);
 
 if (direction === 'push') {
     if (!isSemver) {


### PR DESCRIPTION
This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1. For information on updating to the latest AWS CLI version, see Installing the AWS CLI in the AWS Command Line Interface User Guide.