### PR TITLE
fix: Prevent AWS from using the system's pager

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ function run(cmd, options = {}) {
         encoding: 'utf-8',
         env: {
             ...process.env,
+            AWS_PAGER: '', // Disable the pager.
             AWS_ACCESS_KEY_ID,
             AWS_SECRET_ACCESS_KEY,
         },
@@ -25,7 +26,7 @@ function run(cmd, options = {}) {
 }
 
 const accountLoginPassword = `aws ecr get-login-password --region ${awsRegion}`;
-const accountData = run(`aws sts get-caller-identity --output json`);
+const accountData = run(`aws sts get-caller-identity --output json --region ${awsRegion}`);
 const awsAccountId = JSON.parse(accountData).Account;
 const imageUrl = `https://${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com/${image}`;
 core.setOutput('imageUrl', imageUrl);


### PR DESCRIPTION
This patch prevents the `aws-cli` from piping output to the system's pager (see [AWS CLI version 2 uses a paging program for all output by default](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-output-pager)). Additionally, the region is now explicitly set when fetching account data.

Previously the call to `aws sts get-caller-identity` would crash (exit with `255`) and we would not be able to `JSON.parse()` its results.

Closes #12 